### PR TITLE
chore(analyzers): update analyzers to use .Net Analyzer

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -20,7 +20,7 @@ max_line_length = 9999
 indent_size = 2
 
 # XML indentation
-[*.{csproj,xml}]
+[*.{csproj,xml,ruleset}]
 indent_size = 2
 
 ###############################

--- a/Pushbullet/Configuration/PluginConfiguration.cs
+++ b/Pushbullet/Configuration/PluginConfiguration.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using MediaBrowser.Model.Plugins;
 
 namespace Pushbullet.Configuration
@@ -18,6 +19,7 @@ namespace Pushbullet.Configuration
         /// Gets or sets the configured options.
         /// </summary>
         /// <returns><see cref="IEnumerable{PushbulletOptions}"/>.</returns>
+        [SuppressMessage("Microsoft.Maintainability", "CA1819: Properties should not return arrays", Justification = "XML serializer support")]
         public PushbulletOptions[] Options { get; set; } = Array.Empty<PushbulletOptions>();
     }
 }

--- a/Pushbullet/Notifier.cs
+++ b/Pushbullet/Notifier.cs
@@ -83,7 +83,7 @@ namespace Pushbullet
                 Encoding.UTF8,
                 MediaTypeNames.Application.Json);
             requestMessage.Headers.TryAddWithoutValidation("Access-Token", options.Token);
-            using var responseMessage = await httpClient.SendAsync(requestMessage).ConfigureAwait(false);
+            using var responseMessage = await httpClient.SendAsync(requestMessage, cancellationToken).ConfigureAwait(false);
         }
 
         private static PushbulletOptions? GetOptions(User user)

--- a/Pushbullet/Pushbullet.csproj
+++ b/Pushbullet/Pushbullet.csproj
@@ -7,6 +7,9 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <Nullable>enable</Nullable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
+    <AnalysisMode>AllEnabledByDefault</AnalysisMode>
+    <CodeAnalysisRuleSet>../jellyfin.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 
   <ItemGroup>
@@ -16,7 +19,6 @@
 
   <!-- Code Analyzers-->
   <ItemGroup Condition=" '$(Configuration)' == 'Debug' ">
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.1" PrivateAssets="All" />
     <PackageReference Include="SerilogAnalyzer" Version="0.15.0" PrivateAssets="All" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="All" />
     <PackageReference Include="SmartAnalyzers.MultithreadingAnalyzer" Version="1.1.31" PrivateAssets="All" />
@@ -26,9 +28,5 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="5.0.0" />
   </ItemGroup>
-
-  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
-    <CodeAnalysisRuleSet>../jellyfin.ruleset</CodeAnalysisRuleSet>
-  </PropertyGroup>
 
 </Project>

--- a/jellyfin.ruleset
+++ b/jellyfin.ruleset
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RuleSet Name="Rules for Jellyfin.Server" Description="Code analysis rules for Jellyfin.Server.csproj" ToolsVersion="14.0">
+<RuleSet Name="Rules for Jellyfin" Description="Code analysis rules for Jellyfin" ToolsVersion="14.0">
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
     <!-- disable warning SA1202: 'public' members must come before 'private' members -->
     <Rule Id="SA1202" Action="Info" />
@@ -10,6 +10,8 @@
 
     <!-- disable warning SA1009: Closing parenthesis should be followed by a space. -->
     <Rule Id="SA1009" Action="None" />
+    <!-- disable warning SA1011: Closing square bracket should be followed by a space. -->
+    <Rule Id="SA1011" Action="None" />
     <!-- disable warning SA1101: Prefix local calls with 'this.' -->
     <Rule Id="SA1101" Action="None" />
     <!-- disable warning SA1108: Block statements should not contain embedded comments -->
@@ -30,11 +32,17 @@
     <Rule Id="SA1515" Action="None" />
     <!-- disable warning SA1600: Elements should be documented -->
     <Rule Id="SA1600" Action="None" />
+    <!-- disable warning SA1602: Enumeration items should be documented -->
+    <Rule Id="SA1602" Action="None" />
     <!-- disable warning SA1633: The file header is missing or not located at the top of the file -->
     <Rule Id="SA1633" Action="None" />
   </Rules>
 
-  <Rules AnalyzerId="Microsoft.CodeAnalysis.FxCopAnalyzers" RuleNamespace="Microsoft.Design">
+  <Rules AnalyzerId="Microsoft.CodeAnalysis.NetAnalyzers" RuleNamespace="Microsoft.Design">
+    <!-- error on CA2016: Forward the CancellationToken parameter to methods that take one
+        or pass in 'CancellationToken.None' explicitly to indicate intentionally not propagating the token -->
+    <Rule Id="CA2016" Action="Error" />
+
     <!-- disable warning CA1031: Do not catch general exception types -->
     <Rule Id="CA1031" Action="Info" />
     <!-- disable warning CA1032: Implement standard exception constructors -->
@@ -45,6 +53,8 @@
     <Rule Id="CA1716" Action="Info" />
     <!-- disable warning CA1720: Identifiers should not contain type names -->
     <Rule Id="CA1720" Action="Info" />
+    <!-- disable warning CA1805: Do not initialize unnecessarily -->
+    <Rule Id="CA1805" Action="Info" />
     <!-- disable warning CA1812: internal class that is apparently never instantiated.
         If so, remove the code from the assembly.
         If this class is intended to contain only static members, make it static -->
@@ -53,7 +63,11 @@
     <Rule Id="CA1822" Action="Info" />
     <!-- disable warning CA2000: Dispose objects before losing scope -->
     <Rule Id="CA2000" Action="Info" />
+    <!-- disable warning CA5394: Do not use insecure randomness -->
+    <Rule Id="CA5394" Action="Info" />
 
+    <!-- disable warning CA1014: Mark assemblies with CLSCompliantAttribute -->
+    <Rule Id="CA1014" Action="Info" />
     <!-- disable warning CA1054: Change the type of parameter url from string to System.Uri -->
     <Rule Id="CA1054" Action="None" />
     <!-- disable warning CA1055: URI return values should not be strings -->


### PR DESCRIPTION
### Description

Well this plugins CI was failing due to Analyzer errors, so this is the escape forward and fixing the remaining issues.

### Changes

* updates Analyzer Ruleset
* changes Analyzer from dependency `NetAnalyzers` to integrated .Net Analyzer
* apply fixes to make Analyzer happy 

### Issues

* CI failing :sweat_smile: 
* closes #24 (as it replaces it)